### PR TITLE
fix for issue #28

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -26,3 +26,6 @@ elseif(APPLE)
 	target_link_libraries(gainputtest ${FOUNDATION} ${IOKIT} ${APPKIT})
 endif()
 
+if(MSVC)
+	set_target_properties(gainputtest PROPERTIES LINK_FLAGS "/SUBSYSTEM:CONSOLE")
+endif(MSVC)


### PR DESCRIPTION
fix for issue #28: gainputtest add `LINK_FLAG "/SUBSYSTEM:CONSOLE"` for Visual Studio

Issue reproducing only on Visual Studio.  I tried build current master branch on MinGW MSYS, but build fails. MSYS build errors don't apply to this issue, so i made changes only for visual studio cmake generator. 
I generate Visual Studio 2015 project, built it and then ran tests. All works fine.
![default](https://cloud.githubusercontent.com/assets/5929042/22638152/e51931d2-ec78-11e6-88e9-83b0f4fec062.PNG)