### PR TITLE
In response to issue #36 

### DIFF
--- a/lib/include/gainput/GainputHelpers.h
+++ b/lib/include/gainput/GainputHelpers.h
@@ -25,6 +25,8 @@ namespace gainput
 			}
 		}
 
+		device.ApplyBufferedButton(buttonId, value);
+		
 		state.Set(buttonId, value);
 	}
 

--- a/lib/include/gainput/GainputInputDevice.h
+++ b/lib/include/gainput/GainputInputDevice.h
@@ -154,6 +154,9 @@ public:
 	void SetDebugRenderingEnabled(bool enabled);
 	/// Returns true if debug rendering is enabled, false otherwise.
 	bool IsDebugRenderingEnabled() const { return debugRenderingEnabled_; }
+	
+	/// Used internally to determine whether a button received both a "down" and "up" message in a single update
+	void ApplyBufferedButton(DeviceButtonId buttonId, bool pressed);
 
 #if defined(GAINPUT_DEV) || defined(GAINPUT_ENABLE_RECORDER)
 	/// Returns true if this device is being controlled by a remote device 
@@ -180,6 +183,9 @@ protected:
 	InputState* state_;
 	/// The previous state of this device.
 	InputState* previousState_;
+	
+	/// Stores any button that received both a "down" and "up" message before being handled by InputManager's Update()
+	Array<DeviceButtonId> bufferedButtonInputs_;
 
 	float* deadZones_;
 

--- a/lib/source/gainput/GainputInputDevice.cpp
+++ b/lib/source/gainput/GainputInputDevice.cpp
@@ -10,7 +10,8 @@ InputDevice::InputDevice(InputManager& manager, DeviceId device, unsigned index)
 	deviceId_(device),
 	index_(index),
 	deadZones_(0),
-	debugRenderingEnabled_(false)
+	debugRenderingEnabled_(false),
+	bufferedButtonInputs_(manager.GetAllocator())
 #if defined(GAINPUT_DEV) || defined(GAINPUT_ENABLE_RECORDER)
 	, synced_(false)
 #endif
@@ -26,6 +27,16 @@ void
 InputDevice::Update(InputDeltaState* delta)
 {
 	*previousState_ = *state_;
+	
+	// Apply button downs to previousState_ if both "down" and "up" messages were handled before this update occured
+	for(size_t i = 0;
+			i < bufferedButtonInputs_.size();
+			++i)
+	{
+		previousState_->Set(bufferedButtonInputs_[i], true);
+	}
+	bufferedButtonInputs_.clear();
+	
 #if defined(GAINPUT_DEV)
 	if (synced_)
 	{
@@ -74,6 +85,13 @@ void
 InputDevice::SetDebugRenderingEnabled(bool enabled)
 {
 	debugRenderingEnabled_ = enabled;
+}
+
+void
+InputDevice::ApplyBufferedButton(DeviceButtonId buttonId, bool pressed)
+{
+	if(pressed == false && previousState_->GetBool(buttonId) == false)
+		bufferedButtonInputs_.push_back(buttonId);
 }
 
 size_t


### PR DESCRIPTION
Added an array to `InputDevice` that keeps track of any button that received both a 'down' and 'up' message in the same update. This array then apply itself to `InputDevice`'s `previousState_` so these inputs can be detected.

Note that I assume these input devices are manipulated using messages from the platform, specifically the Windows platform. I'm not familiar with how other platforms work in this library, but this should only affect code that uses the `HandleButton(...)` function (besides the additional memory footprint of one `Array<>` in each `InputDevice`