### PR TITLE
Build gainput as a shared library by using BUILD_SHARED option in CMake.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,7 @@
 cmake_minimum_required(VERSION 2.8)
+
+project(gainput)
+
 set(GAINPUT_MAJOR_VERSION 1)
 set(GAINPUT_MINOR_VERSION 0)
 set(GAINPUT_PATCH_VERSION 0)
@@ -6,30 +9,29 @@ set(GAINPUT_VERSION ${GAINPUT_MAJOR_VERSION}.${GAINPUT_MINOR_VERSION}.${GAINPUT_
 
 option(GAINPUT_SAMPLES "Build Samples for Gainput" ON)
 option(GAINPUT_TESTS "Build Tests for Gainput" ON)
-option(GAINPUT_BUILD_SHARED "BUILD_SHARED" ON)
-option(GAINPUT_BUILD_STATIC "BUILD_STATIC" ON)
+option(BUILD_SHARED_LIBS "Build gainput as a shared library." ON)
 
 if(!WIN32)
-	set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -pedantic -Wextra")
+  set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -pedantic -Wextra")
 else()
-	set(XINPUT "Xinput9_1_0")
-	if ( ${CMAKE_SYSTEM_VERSION} LESS 6.1 )
-		set(XINPUT, "xinput")
-	endif()
+  set(XINPUT "Xinput9_1_0")
+  if ( ${CMAKE_SYSTEM_VERSION} LESS 6.1 )
+    set(XINPUT, "xinput")
+  endif()
 endif()
 
 if(ANDROID)
-	include(extern/cmake/AndroidNdkModules.cmake)
-	android_ndk_import_module_native_app_glue()
+  include(extern/cmake/AndroidNdkModules.cmake)
+  android_ndk_import_module_native_app_glue()
 endif()
 
 add_subdirectory(lib)
 
 if(GAINPUT_SAMPLES)
-	add_subdirectory(samples)
+  add_subdirectory(samples)
 endif()
 
 if(GAINPUT_TESTS)
-	add_subdirectory(test)
+  add_subdirectory(test)
 endif()
 

--- a/lib/CMakeLists.txt
+++ b/lib/CMakeLists.txt
@@ -15,60 +15,49 @@ if(APPLE)
 	file(GLOB_RECURSE mmsources source/*.mm)
 endif()
 
-## build STATIC *or* SHARED
-if (GAINPUT_BUILD_SHARED)
-  message(STATUS "..Building shared libraries (-DGAINPUT_BUILD_SHARED=OFF to disable)")
-  add_library(gainput SHARED ${sources} ${mmsources})
-  set_target_properties(gainput PROPERTIES
-    OUTPUT_NAME gainput
-    DEBUG_POSTFIX -d
-    VERSION ${GAINPUT_VERSION}
-    SOVERSION ${GAINPUT_MAJOR_VERSION}
-    FOLDER gainput
-  )
-  set(install_libs ${install_libs} gainput)
-endif (GAINPUT_BUILD_SHARED)
-
-if (GAINPUT_BUILD_STATIC)
-  message(STATUS "..Building static libraries (-DGAINPUT_BUILD_STATIC=OFF to disable)")
-  add_library(gainputstatic STATIC ${sources} ${mmsources})
-  set_target_properties(gainputstatic PROPERTIES DEBUG_POSTFIX -d FOLDER gainput)
-  set(install_libs ${install_libs} gainputstatic)
-endif (GAINPUT_BUILD_STATIC)
+add_library(gainput ${sources} ${mmsources})
+set_target_properties(gainput PROPERTIES
+OUTPUT_NAME gainput
+DEBUG_POSTFIX -d
+VERSION ${GAINPUT_VERSION}
+SOVERSION ${GAINPUT_MAJOR_VERSION}
+FOLDER gainput
+)
+set(install_libs ${install_libs} gainput)
 
 if(WIN32)
-	target_link_libraries(gainput ${XINPUT} ws2_32)
-	target_link_libraries(gainputstatic ${XINPUT} ws2_32)
-	add_definitions(-DGAINPUT_LIB_DYNAMIC=1)
+  target_link_libraries(gainput ${XINPUT} ws2_32)
+  if(BUILD_SHARED_LIBS)
+    add_definitions(-DGAINPUT_LIB_DYNAMIC=1)
+  endif(BUILD_SHARED_LIBS)
 elseif(ANDROID)
-	target_link_libraries(gainputstatic native_app_glue log android)
-	target_link_libraries(gainput native_app_glue log android)
+  target_link_libraries(gainput native_app_glue log android)
 elseif(APPLE)
-	find_library(FOUNDATION Foundation)
-	find_library(IOKIT IOKit)
+  find_library(FOUNDATION Foundation)
+  find_library(IOKIT IOKit)
   find_library(GAME_CONTROLLER GameController)
-	target_link_libraries(gainput ${FOUNDATION} ${IOKIT} ${GAME_CONTROLLER})
+  target_link_libraries(gainput ${FOUNDATION} ${IOKIT} ${GAME_CONTROLLER})
   if(IOS)
-      find_library(UIKIT UIKit)
-      find_library(COREMOTION CoreMotion)
-      find_library(QUARTZCORE QuartzCore)
-      target_link_libraries(gainput ${UIKIT} ${COREMOTION})
+    find_library(UIKIT UIKit)
+    find_library(COREMOTION CoreMotion)
+    find_library(QUARTZCORE QuartzCore)
+    target_link_libraries(gainput ${UIKIT} ${COREMOTION})
   else()
-      find_library(APPKIT AppKit)
-      target_link_libraries(gainput ${APPKIT})
+    find_library(APPKIT AppKit)
+    target_link_libraries(gainput ${APPKIT})
   endif()
 endif()
 
 # Library installation directory
 if(NOT DEFINED CMAKE_INSTALL_LIBDIR)
-    set(CMAKE_INSTALL_LIBDIR lib)
+  set(CMAKE_INSTALL_LIBDIR lib)
 endif(NOT DEFINED CMAKE_INSTALL_LIBDIR)
 set(libdir ${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_LIBDIR})
 
 install(
-    DIRECTORY "include/gainput"
-    DESTINATION "include"
-    FILES_MATCHING PATTERN "*.h"
+  DIRECTORY "include/gainput"
+  DESTINATION "include"
+  FILES_MATCHING PATTERN "*.h"
 )
 
 install(

--- a/lib/include/gainput/gainput.h
+++ b/lib/include/gainput/gainput.h
@@ -161,7 +161,7 @@ template <class T> T Abs(T a) { return a < T() ? -a : a; }
  * The pages can also be found hosted here:
  * http://gainput.johanneskuhlmann.de/html5client/
  */
-void DevSetHttp(bool enable);
+void GAINPUT_LIBEXPORT DevSetHttp(bool enable);
 }
 
 #define GAINPUT_VER_MAJOR_SHIFT		16

--- a/samples/basic/CMakeLists.txt
+++ b/samples/basic/CMakeLists.txt
@@ -25,7 +25,7 @@ else()
 	add_executable(basicsample WIN32 ${sources} ${mmsources})
 endif()
 
-target_link_libraries(basicsample gainputstatic)
+target_link_libraries(basicsample gainput)
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 	target_link_libraries(basicsample X11 GL rt)

--- a/samples/dynamic/CMakeLists.txt
+++ b/samples/dynamic/CMakeLists.txt
@@ -13,7 +13,7 @@ else()
 	add_executable(dynamicsample WIN32 ${sources} ${sfwsources})
 endif()
 
-target_link_libraries(dynamicsample gainputstatic)
+target_link_libraries(dynamicsample gainput)
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 	target_link_libraries(dynamicsample X11 GL rt)

--- a/samples/gesture/CMakeLists.txt
+++ b/samples/gesture/CMakeLists.txt
@@ -13,7 +13,7 @@ else()
 	add_executable(gesturesample WIN32 ${sources} ${sfwsources})
 endif()
 
-target_link_libraries(gesturesample gainputstatic)
+target_link_libraries(gesturesample gainput)
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 	target_link_libraries(gesturesample X11 GL rt)

--- a/samples/listener/CMakeLists.txt
+++ b/samples/listener/CMakeLists.txt
@@ -13,7 +13,7 @@ else()
 	add_executable(listenersample WIN32 ${sources} ${sfwsources})
 endif()
 
-target_link_libraries(listenersample gainputstatic)
+target_link_libraries(listenersample gainput)
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 	target_link_libraries(listenersample X11 GL rt)

--- a/samples/recording/CMakeLists.txt
+++ b/samples/recording/CMakeLists.txt
@@ -13,7 +13,7 @@ else()
 	add_executable(recordingsample WIN32 ${sources} ${sfwsources})
 endif()
 
-target_link_libraries(recordingsample gainputstatic)
+target_link_libraries(recordingsample gainput)
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 	target_link_libraries(recordingsample X11 GL rt)

--- a/samples/sync/CMakeLists.txt
+++ b/samples/sync/CMakeLists.txt
@@ -13,7 +13,7 @@ else()
 	add_executable(syncsample WIN32 ${sources} ${sfwsources})
 endif()
 
-target_link_libraries(syncsample gainputstatic)
+target_link_libraries(syncsample gainput)
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 	target_link_libraries(syncsample X11 GL rt)

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -22,7 +22,7 @@ else()
 	set(APPKIT "")
 endif()
 
-target_link_libraries(gainputtest gainputstatic)
+target_link_libraries(gainputtest gainput)
 
 if(${CMAKE_SYSTEM_NAME} MATCHES "Linux")
 	target_link_libraries(gainputtest X11 GL rt)


### PR DESCRIPTION
As mentioned in issue #78, it is not possible to generate the project in CMake if either `GAIN_BUILD_SHARED` or `GAIN_BUILD_STATIC` is disabled while generating the project. This pull request fixes this issue by relying on the `BUILD_SHARED_LIBS` built-in option in CMake.
The **gainputstatic** project should not be necessary if we rely on the fact that the user can switch between the shared and static variants by specifying the `BUILD_SHARED_LIBS` option accordingly.