### PR TITLE
Fix the build instructions in readme...

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,9 +79,10 @@ Building
 By default, Gainput is built using [CMake](http://www.cmake.org/).
 
 1. Run `mkdir build`
-1. Run `cmake ..`
-1. Run `make`
-1. The library can be found in `lib/`, the executables in `samples/`.
+2. Run `cd build`
+3. Run `cmake ..`
+4. Run `make`
+5. The library can be found in `lib/`, the executables in `samples/`.
 
 
 Contributing


### PR DESCRIPTION
...by including a 'cd' into the build folder before the 'cmake ..'